### PR TITLE
Set correct variable type for getopt

### DIFF
--- a/charging.c
+++ b/charging.c
@@ -92,7 +92,7 @@ int main (int argc, char** argv) {
         .w = screen_w / 8,
         .h = screen_w / 8
     };
-    char opt;
+    int opt;
     while ((opt = getopt(argc, argv, "tpcf:")) != -1) {
         switch (opt) {
             case 't': flag_test = 1; break;


### PR DESCRIPTION
With `char` it works only for `x86_64`, building it for `armhf` using `pmbootstrap` was showing always the usage text.
For reference: also in `osk-sdl` is set to `int`